### PR TITLE
Remove negator from hidetitle prop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -220,7 +220,7 @@ const Gobi = React.forwardRef((props: any) => {
           data-gobi-show-play-icon="${showPlayIcon.toString()}"
           data-gobi-auto-segue="true"
           data-gobi-title-font-color="${titleFontColor}"
-          data-gobi-hide-title="${!hideTitle}"
+          data-gobi-hide-title="${hideTitle}"
           data-gobi-auto-start-with-sound="${!autoStartWithSound}">
       </div>`
     }


### PR DESCRIPTION
It seems the hideTitle prop is the inverted value as it should be. Setting "Display Story Name" in the editor to false, makes it display in the page, however, it hides it in the preview.

This is the first thing I saw that could be the reason, but I have not tested nor pulled it locally - So please evaluate and test this before merging it. 